### PR TITLE
main: updating the version properly pin patch version

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ EXAMPLE
 ```hcl
 module "dcos-public-agents-install" {
   source  = "terraform-dcos/dcos-install-public-agents-remote-exec/null"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   bootstrap_private_ip = "${module.dcos-infrastructure.bootstrap.private_ip}"
   bootstrap_port       = "80"

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@
  *```hcl
  * module "dcos-public-agents-install" {
  *   source  = "terraform-dcos/dcos-install-public-agents-remote-exec/null"
- *   version = "~> 0.1"
+ *   version = "~> 0.1.0"
  *
  *   bootstrap_private_ip = "${module.dcos-infrastructure.bootstrap.private_ip}"
  *   bootstrap_port       = "80"
@@ -24,7 +24,7 @@
 
 module "dcos-mesos-public-agent" {
   source  = "dcos-terraform/dcos-core/template"
-  version = "~> 0.1"
+  version = "~> 0.1.0"
 
   # source               = "/Users/julferts/git/github.com/fatz/tf_dcos_core"
   bootstrap_private_ip = "${var.bootstrap_private_ip}"


### PR DESCRIPTION
This updates the version behaivor to have ~> 0.1.0: any non-beta version >= 0.1.0 and < 0.2.0

https://www.terraform.io/docs/modules/usage.html#gt-1-2